### PR TITLE
See issue 19. This should fix the issue if uncommented again.

### DIFF
--- a/src/scans/permissions_scan.c
+++ b/src/scans/permissions_scan.c
@@ -110,7 +110,8 @@ static void check_global_write(All_Results *ar, File_Info *fi)
         //     add_issue(LOW, AUDIT, fi->location, ar, issue_buf, "ENUMY failed to stat the parent directory");
         //     return;
         // }
-        // struct passwd *data = getpwuid(stats.st_uid);
+        // // John: getpwuid is not re-entrant. Using getpwuid_r should fix this issue.
+        // struct passwd *data = getpwuid_r(stats.st_uid);
         // if (data == NULL)
         // {
         //     log_error_errno_loc(ar, "Failed to stat directory", parent_buf, errno);


### PR DESCRIPTION
see #19 

getpwuid should not be used in multit-hreaded programs. getpwuid_r is the direct drop in that is reentrant. Use this instead and that issue should disappear.

This only add that as a comment, but 'un-commenting'  should now be safe.